### PR TITLE
Upgraded BenchmarkDotNet from version 0.11.0 to 0.12.0

### DIFF
--- a/Farmhash.Sharp.Benchmarks/BaseConfig.cs
+++ b/Farmhash.Sharp.Benchmarks/BaseConfig.cs
@@ -29,8 +29,8 @@ namespace Farmhash.Sharp.Benchmarks
             Add(new Job("core-64bit").With(CoreRuntime.Core21).WithId("Core")
                 .With(CsProjCoreToolchain.NetCoreApp21));
 
-            Add(new Job("net-legacy-32bit", EnvironmentMode.LegacyJitX86).With(CsProjClassicNetToolchain.Net48));
-            Add(new Job("net-legacy-64bit", EnvironmentMode.LegacyJitX64).With(CsProjClassicNetToolchain.Net48));
+            Add(new Job("net-legacy-32bit", EnvironmentMode.LegacyJitX86).With(CsProjClassicNetToolchain.Net461));
+            Add(new Job("net-legacy-64bit", EnvironmentMode.LegacyJitX64).With(CsProjClassicNetToolchain.Net461));
 
             Add(new Job("net-ryu-64bit", EnvironmentMode.RyuJitX64));
 

--- a/Farmhash.Sharp.Benchmarks/BaseConfig.cs
+++ b/Farmhash.Sharp.Benchmarks/BaseConfig.cs
@@ -11,12 +11,14 @@ namespace Farmhash.Sharp.Benchmarks
     {
         public BaseConfig()
         {
-            Add(new CsvExporter(CsvSeparator.CurrentCulture,
-                new BenchmarkDotNet.Reports.SummaryStyle
-                {
-                    PrintUnitsInContent = false,
-                    TimeUnit = BenchmarkDotNet.Horology.TimeUnit.Nanosecond
-                }));
+            Add(new CsvExporter(
+                CsvSeparator.CurrentCulture,
+                new BenchmarkDotNet.Reports.SummaryStyle(
+                    false,
+                    null,
+                    BenchmarkDotNet.Horology.TimeUnit.Nanosecond,
+                    false)
+            ));
 
             Add(StatisticColumn.Mean);
             Add(StatisticColumn.StdErr);
@@ -24,16 +26,16 @@ namespace Farmhash.Sharp.Benchmarks
             Add(StatisticColumn.Median);
 
             // dotnet cli toolchain supports only x64 compilation
-            Add(new Job("core-64bit", EnvironmentMode.Core)
+            Add(new Job("core-64bit").With(CoreRuntime.Core21).WithId("Core")
                 .With(CsProjCoreToolchain.NetCoreApp21));
 
-            Add(new Job("net-legacy-32bit", EnvironmentMode.LegacyJitX86));
-            Add(new Job("net-legacy-64bit", EnvironmentMode.LegacyJitX64));
+            Add(new Job("net-legacy-32bit", EnvironmentMode.LegacyJitX86).With(CsProjClassicNetToolchain.Net48));
+            Add(new Job("net-legacy-64bit", EnvironmentMode.LegacyJitX64).With(CsProjClassicNetToolchain.Net48));
 
             Add(new Job("net-ryu-64bit", EnvironmentMode.RyuJitX64));
 
-            Add(new Job("mono-64bit", EnvironmentMode.Mono).With(Platform.X64));
-            Add(new Job("mono-32bit", EnvironmentMode.Mono).With(Platform.X86));
+            Add(new Job("mono-64bit").With(MonoRuntime.Default).With(Platform.X64));
+            Add(new Job("mono-32bit").With(MonoRuntime.Default).With(Platform.X86));
         }
     }
 }

--- a/Farmhash.Sharp.Benchmarks/Farmhash.Sharp.Benchmarks.csproj
+++ b/Farmhash.Sharp.Benchmarks/Farmhash.Sharp.Benchmarks.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
     <PackageReference Include="System.Data.HashFunction.CityHash" Version="2.0.0" />
     <PackageReference Include="System.Data.HashFunction.SpookyHash" Version="2.0.0" />
     <PackageReference Include="SpookilySharp" Version="1.2.0" />


### PR DESCRIPTION
Bumping some dependencies as well.
There is some fix due to several refactoring in BenchmarkDotNet.
* `BenchmarkDotNet.Reports.SummaryStyle` : They removed the public setters, so you have to use the constructor parameters. I choose some values based on what it was before the refactoring.
* `EnvironmentMode.Core` does not exists anymore. I replaced it with `.With(CoreRuntime.Core21).WithId("Core")` based on what they did to fix there own code when they introduced that change.
* `EnvironmentMode.Mono` does not exists anymore. I replaced it with `.With(MonoRuntime.Default)` based on what they did to fix there own code when they introduced that change.
* The toolchain now defaults to .net core, so I had to add `.With(CsProjClassicNetToolchain.Net48)` to have `EnvironmentMode.LegacyJit*` work.
